### PR TITLE
removed unused variable in the example code of semantic event

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -188,7 +188,6 @@ class TapSemanticEvent extends SemanticsEvent {
 /// }
 ///
 /// class _MyWidgetState extends State<MyWidget> {
-///   bool noticeAccepted = false;
 ///   final GlobalKey mykey = GlobalKey();
 ///
 ///   @override


### PR DESCRIPTION
removes unused variable in the example code of semantic events

https://api.flutter.dev/flutter/semantics/FocusSemanticEvent-class.html